### PR TITLE
Keep sections in LitScan hits

### DIFF
--- a/consumer/views/submit_job.py
+++ b/consumer/views/submit_job.py
@@ -141,18 +141,22 @@ def get_sections(tree, include_abstract=False):
 
     section_map = {}
     for sec in sections:
-        sec_title = sec.find("title").text
-        if re.match(".*intro.+", sec_title.lower()):
-            section_map['intro'] = sec
-        elif re.match(".*results", sec_title.lower()):
-            section_map['results'] = sec
-        elif re.match(".*discussion", sec_title.lower()):
-            section_map['discussion'] = sec
-        elif re.match(".*conclusion.*", sec_title.lower()):
-            section_map['conclusion'] = sec
-        elif re.match(".*method.+", sec_title.lower()):
-            section_map['method'] = sec
+        sec_title = sec.find("title")
+        if sec_title is not None:
+            if re.match(".*intro.+", sec_title.text.lower()):
+                section_map['intro'] = sec
+            elif re.match(".*results", sec_title.text.lower()):
+                section_map['results'] = sec
+            elif re.match(".*discussion", sec_title.text.lower()):
+                section_map['discussion'] = sec
+            elif re.match(".*conclusion.*", sec_title.text.lower()):
+                section_map['conclusion'] = sec
+            elif re.match(".*method.+", sec_title.text.lower()):
+                section_map['method'] = sec
+            else:
+                section_map['other'] = sec
         else:
+            # No title - don't know what it is, put it in other
             section_map['other'] = sec
 
     if include_abstract:

--- a/database/models.py
+++ b/database/models.py
@@ -129,6 +129,7 @@ BodySentence = sa.Table(
     sa.Column('id', sa.Integer, primary_key=True),
     sa.Column('result_id', sa.Integer, sa.ForeignKey('result.id')),
     sa.Column('sentence', sa.Text),
+    sa.Column('location', sa.Text),
 )
 
 """Job related to which DB"""
@@ -238,6 +239,7 @@ async def migrate(env):
                   id SERIAL PRIMARY KEY,
                   result_id INTEGER,
                   sentence TEXT,
+                  location TEXT,
                   FOREIGN KEY (result_id) REFERENCES result(id) ON UPDATE CASCADE ON DELETE CASCADE)
             ''')
 


### PR DESCRIPTION
This PR allows litscan to keep track of which article section a hit came from, so that we can better filter hits downstream.

I've tested it locally, and it seems to work ok. One thing that is required is the addition of a `location` column to the `body_sentence` table in the database